### PR TITLE
Moose 2.1100 deprecated the enum(qw(...)) syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension HTTP::Throwable
 
 {{$NEXT}}
+        - removed use of deprecated enum syntax
 
 0.017     2013-09-17 09:04:45 Asia/Tokyo
         - removed use of deprecated Class::MOP::load_class

--- a/lib/HTTP/Throwable/Role/Status/MethodNotAllowed.pm
+++ b/lib/HTTP/Throwable/Role/Status/MethodNotAllowed.pm
@@ -9,11 +9,11 @@ with(
     'HTTP::Throwable::Role::BoringText',
 );
 
-enum 'HTTP::Throwable::Type::Method' => qw[
+enum 'HTTP::Throwable::Type::Method' => [ qw[
     OPTIONS GET HEAD
     POST PUT DELETE
     TRACE CONNECT
-];
+] ];
 
 # TODO: Consider adding a coersion to upper-case lower-cased strings and to
 # uniq the given input.  -- rjbs, 2011-02-21


### PR DESCRIPTION
Oops, I sent you a PR already but missed this other deprecation (it just warns, rather than dies)
