### PR TITLE
Transmoogrification - Moose => Moo conversion of HTTP::Throwable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ To install this module type the following:
 
 This module requires these other modules and libraries:
 
-    Moose
-    MooseX::StrictConstructor
+    Moo
+    MooX::StrictConstructor
     Throwable
     Plack
     List::AllUtils
+    Types::Standard
+    Type::Tiny
+    Package::Variant
+    namespace::clean
 
 ## Copyright and License
 

--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ List::AllUtils            = 0
 Types::Standard           = 0
 Type::Tiny                = 0
 Package::Variant          = 0
+namespace::clean          = 0
 
 [Prereqs / TestRequires]
 Test::More            = 0.88

--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,7 @@ Plack                     = 0.9967
 List::AllUtils            = 0
 Types::Standard           = 0
 Type::Tiny                = 0
+Package::Variant          = 0
 
 [Prereqs / TestRequires]
 Test::More            = 0.88

--- a/dist.ini
+++ b/dist.ini
@@ -11,8 +11,8 @@ copyright_year   = 2011
 authority = cpan:STEVAN
 
 [Prereqs]
-Moose                     = 1.23
-MooseX::StrictConstructor = 0.12
+Moo                       = 0
+MooX::StrictConstructor   = 0
 Throwable                 = 0.102080
 Plack                     = 0.9967
 List::AllUtils            = 0

--- a/dist.ini
+++ b/dist.ini
@@ -11,7 +11,7 @@ copyright_year   = 2011
 authority = cpan:STEVAN
 
 [Prereqs]
-Moo                       = 0
+Moo                       = 1.004003
 MooX::StrictConstructor   = 0
 Throwable                 = 0.102080
 Plack                     = 0.9967

--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,8 @@ MooseX::StrictConstructor = 0.12
 Throwable                 = 0.102080
 Plack                     = 0.9967
 List::AllUtils            = 0
+Types::Standard           = 0
+Type::Tiny                = 0
 
 [Prereqs / TestRequires]
 Test::More            = 0.88

--- a/lib/HTTP/Throwable.pm
+++ b/lib/HTTP/Throwable.pm
@@ -1,9 +1,8 @@
 package HTTP::Throwable;
-use Moose::Role;
-use MooseX::StrictConstructor;
-use MooseX::Role::WithOverloading 0.09;
 
 use Types::Standard qw(Int Str ArrayRef);
+
+use Moo::Role;
 
 use overload
     '&{}' => 'to_app',
@@ -89,7 +88,7 @@ sub is_server_error {
     return $status >= 500 && $status < 600;
 }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable.pm
+++ b/lib/HTTP/Throwable.pm
@@ -3,6 +3,8 @@ use Moose::Role;
 use MooseX::StrictConstructor;
 use MooseX::Role::WithOverloading 0.09;
 
+use Types::Standard qw(Int Str ArrayRef);
+
 use overload
     '&{}' => 'to_app',
     '""'  => 'as_string',
@@ -14,25 +16,25 @@ with 'Throwable';
 
 has 'status_code' => (
     is       => 'ro',
-    isa      => 'Int',
+    isa      => Int,
     builder  => 'default_status_code',
 );
 
 has 'reason' => (
     is       => 'ro',
-    isa      => 'Str',
+    isa      => Str,
     required => 1,
     builder  => 'default_reason',
 );
 
 has 'message' => (
     is  => 'ro',
-    isa => 'Str',
+    isa => Str,
     predicate => 'has_message',
 );
 
 # TODO: type this attribute more strongly -- rjbs, 2011-02-21
-has 'additional_headers' => ( is => 'ro', isa => 'ArrayRef' );
+has 'additional_headers' => ( is => 'ro', isa => ArrayRef );
 
 sub build_headers {
     my ($self, $body) = @_;

--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Factory;
 use Moose;
 
+use HTTP::Throwable::Variant;
+
 use Sub::Exporter::Util ();
 use Sub::Exporter -setup => {
   exports => [
@@ -67,20 +69,16 @@ sub class_for {
 
     Module::Runtime::use_module($_) for @roles;
 
-    my $class = Moose::Meta::Class->create_anon_class(
+    my $class = HTTP::Throwable::Variant->build_variant(
         superclasses => [ $self->base_class ],
         roles        => [
           $self->core_roles,
           $self->extra_roles,
           @roles
         ],
-        cache        => 1,
     );
 
-    require MooseX::StrictConstructor;
-    MooseX::StrictConstructor->import({ into => $class->name });
-
-    return $class->name;
+    return $class;
 }
 
 1;

--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -1,5 +1,4 @@
 package HTTP::Throwable::Factory;
-use Moose;
 
 use HTTP::Throwable::Variant;
 
@@ -11,6 +10,9 @@ use Sub::Exporter -setup => {
   ],
 };
 use Module::Runtime;
+
+use Moo;
+
 
 sub throw {
     my $factory = shift;
@@ -55,7 +57,7 @@ sub roles_for_no_ident {
     );
 }
 
-sub base_class { 'Moose::Object' }
+sub base_class { 'Moo::Object' }
 
 sub class_for {
     my ($self, $ident) = @_;
@@ -175,7 +177,7 @@ L<HTTP::Throwable::Role::BoringText>.
 =head2 base_class
 
 This is the base class that will be subclassed and into which all the roles
-will be composed.  By default, it is L<Moose::Object>, the universal base Moose
+will be composed.  By default, it is L<Moo::Object>, the universal base Moo
 class.
 
 =head2 core_roles

--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -12,6 +12,7 @@ use Sub::Exporter -setup => {
 use Module::Runtime;
 
 use Moo;
+use namespace::clean;
 
 
 sub throw {

--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -58,7 +58,7 @@ sub roles_for_no_ident {
     );
 }
 
-sub base_class { 'Moo::Object' }
+sub base_class { () }
 
 sub class_for {
     my ($self, $ident) = @_;

--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -1,5 +1,8 @@
 package HTTP::Throwable::Factory;
 
+use strict;
+use warnings;
+
 use HTTP::Throwable::Variant;
 
 use Sub::Exporter::Util ();
@@ -10,9 +13,6 @@ use Sub::Exporter -setup => {
   ],
 };
 use Module::Runtime;
-
-use Moo;
-use namespace::clean;
 
 
 sub throw {

--- a/lib/HTTP/Throwable/Role/BoringText.pm
+++ b/lib/HTTP/Throwable/Role/BoringText.pm
@@ -1,9 +1,8 @@
 package HTTP::Throwable::Role::BoringText;
-use Moose::Role;
+use Moo::Role;
 
 sub text_body { $_[0]->status_line }
 
-no Moose::Role;
 1;
 
 __END__

--- a/lib/HTTP/Throwable/Role/BoringText.pm
+++ b/lib/HTTP/Throwable/Role/BoringText.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::BoringText;
+
 use Moo::Role;
 
 sub text_body { $_[0]->status_line }

--- a/lib/HTTP/Throwable/Role/Generic.pm
+++ b/lib/HTTP/Throwable/Role/Generic.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Generic;
-use Moose::Role;
 
 use Carp qw(confess);
+
+use Moo::Role;
 
 with 'HTTP::Throwable';
 
@@ -13,7 +14,7 @@ sub default_reason {
     confess "generic HTTP::Throwable must be given reason in constructor";
 }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Generic.pm
+++ b/lib/HTTP/Throwable/Role/Generic.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Generic;
 use Moose::Role;
 
+use Carp qw(confess);
+
 with 'HTTP::Throwable';
 
 sub default_status_code {

--- a/lib/HTTP/Throwable/Role/NoBody.pm
+++ b/lib/HTTP/Throwable/Role/NoBody.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::NoBody;
-use Moose::Role;
+use Moo::Role;
 
 sub body { return }
 
@@ -13,7 +13,6 @@ sub body_headers {
 
 sub as_string { $_[0]->status_line }
 
-no Moose::Role;
 1;
 
 __END__

--- a/lib/HTTP/Throwable/Role/NoBody.pm
+++ b/lib/HTTP/Throwable/Role/NoBody.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::NoBody;
+
 use Moo::Role;
 
 sub body { return }

--- a/lib/HTTP/Throwable/Role/Redirect.pm
+++ b/lib/HTTP/Throwable/Role/Redirect.pm
@@ -1,9 +1,11 @@
 package HTTP::Throwable::Role::Redirect;
 use Moose::Role;
 
+use Types::Standard qw(Str);
+
 has 'location' => (
     is       => 'ro',
-    isa      => 'Str',
+    isa      => Str,
     required => 1,
 );
 

--- a/lib/HTTP/Throwable/Role/Redirect.pm
+++ b/lib/HTTP/Throwable/Role/Redirect.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Redirect;
-use Moose::Role;
 
 use Types::Standard qw(Str);
+
+use Moo::Role;
 
 has 'location' => (
     is       => 'ro',
@@ -18,7 +19,7 @@ around 'build_headers' => sub {
     return $headers;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 # ABSTRACT: an exception that is a redirect

--- a/lib/HTTP/Throwable/Role/Status/BadGateway.pm
+++ b/lib/HTTP/Throwable/Role/Status/BadGateway.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::BadGateway;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 502 }
 sub default_reason      { 'Bad Gateway' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/BadGateway.pm
+++ b/lib/HTTP/Throwable/Role/Status/BadGateway.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::BadGateway;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/BadRequest.pm
+++ b/lib/HTTP/Throwable/Role/Status/BadRequest.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::BadRequest;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/BadRequest.pm
+++ b/lib/HTTP/Throwable/Role/Status/BadRequest.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::BadRequest;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -10,7 +10,7 @@ sub default_status_code { 400 }
 
 sub default_reason { 'Bad Request' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/Conflict.pm
+++ b/lib/HTTP/Throwable/Role/Status/Conflict.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::Conflict;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 409 }
 sub default_reason      { 'Conflict' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/Conflict.pm
+++ b/lib/HTTP/Throwable/Role/Status/Conflict.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::Conflict;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/ExpectationFailed.pm
+++ b/lib/HTTP/Throwable/Role/Status/ExpectationFailed.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::ExpectationFailed;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 417 }
 sub default_reason      { 'Expectation Failed' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/ExpectationFailed.pm
+++ b/lib/HTTP/Throwable/Role/Status/ExpectationFailed.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::ExpectationFailed;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/Forbidden.pm
+++ b/lib/HTTP/Throwable/Role/Status/Forbidden.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::Forbidden;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/Forbidden.pm
+++ b/lib/HTTP/Throwable/Role/Status/Forbidden.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::Forbidden;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 403 }
 sub default_reason      { 'Forbidden' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/Found.pm
+++ b/lib/HTTP/Throwable/Role/Status/Found.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::Found;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/Found.pm
+++ b/lib/HTTP/Throwable/Role/Status/Found.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::Found;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -10,7 +10,7 @@ with(
 sub default_status_code { 302 }
 sub default_reason      { 'Found' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/GatewayTimeout.pm
+++ b/lib/HTTP/Throwable/Role/Status/GatewayTimeout.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::GatewayTimeout;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/GatewayTimeout.pm
+++ b/lib/HTTP/Throwable/Role/Status/GatewayTimeout.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::GatewayTimeout;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 504 }
 sub default_reason      { 'Gateway Timeout' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/Gone.pm
+++ b/lib/HTTP/Throwable/Role/Status/Gone.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::Gone;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/Gone.pm
+++ b/lib/HTTP/Throwable/Role/Status/Gone.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::Gone;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 410 }
 sub default_reason      { 'Gone' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/HTTPVersionNotSupported.pm
+++ b/lib/HTTP/Throwable/Role/Status/HTTPVersionNotSupported.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::HTTPVersionNotSupported;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/HTTPVersionNotSupported.pm
+++ b/lib/HTTP/Throwable/Role/Status/HTTPVersionNotSupported.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::HTTPVersionNotSupported;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 505 }
 sub default_reason      { 'HTTP Version Not Supported' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/ImATeapot.pm
+++ b/lib/HTTP/Throwable/Role/Status/ImATeapot.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::ImATeapot;
+
 use Types::Standard qw(Bool);
 
 use Moo::Role;

--- a/lib/HTTP/Throwable/Role/Status/ImATeapot.pm
+++ b/lib/HTTP/Throwable/Role/Status/ImATeapot.pm
@@ -1,6 +1,7 @@
 package HTTP::Throwable::Role::Status::ImATeapot;
-use Moose::Role;
 use Types::Standard qw(Bool);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -39,7 +40,7 @@ sub text_body {
     return $base;
 }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/ImATeapot.pm
+++ b/lib/HTTP/Throwable/Role/Status/ImATeapot.pm
@@ -1,12 +1,13 @@
 package HTTP::Throwable::Role::Status::ImATeapot;
 use Moose::Role;
+use Types::Standard qw(Bool);
 
 with(
     'HTTP::Throwable',
 );
 
-has 'short' => (is => 'ro', isa => 'Bool', default => 0);
-has 'stout' => (is => 'ro', isa => 'Bool', default => 0);
+has 'short' => (is => 'ro', isa => Bool, default => 0);
+has 'stout' => (is => 'ro', isa => Bool, default => 0);
 
 sub default_status_code { 418 }
 sub default_reason      { q{I'm a teapot} }

--- a/lib/HTTP/Throwable/Role/Status/InternalServerError.pm
+++ b/lib/HTTP/Throwable/Role/Status/InternalServerError.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Status::InternalServerError;
 use Moose::Role;
 
+use Types::Standard qw(Bool);
+
 with(
     'HTTP::Throwable',
     'StackTrace::Auto',
@@ -9,7 +11,7 @@ with(
 sub default_status_code { 500 }
 sub default_reason      { 'Internal Server Error' }
 
-has 'show_stack_trace' => ( is => 'ro', isa => 'Bool', default => 1 );
+has 'show_stack_trace' => ( is => 'ro', isa => Bool, default => 1 );
 
 sub text_body {
     my ($self) = @_;

--- a/lib/HTTP/Throwable/Role/Status/InternalServerError.pm
+++ b/lib/HTTP/Throwable/Role/Status/InternalServerError.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Status::InternalServerError;
-use Moose::Role;
 
 use Types::Standard qw(Bool);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -23,7 +24,7 @@ sub text_body {
     return $out;
 }
 
-no Moose; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/LengthRequired.pm
+++ b/lib/HTTP/Throwable/Role/Status/LengthRequired.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::LengthRequired;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 411 }
 sub default_reason      { 'Length Required' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/LengthRequired.pm
+++ b/lib/HTTP/Throwable/Role/Status/LengthRequired.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::LengthRequired;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/MethodNotAllowed.pm
+++ b/lib/HTTP/Throwable/Role/Status/MethodNotAllowed.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Status::MethodNotAllowed;
 use Moose::Role;
-use Moose::Util::TypeConstraints;
+
+use Type::Utils qw(subtype as where enum);
+use Types::Standard qw(ArrayRef);
 
 use List::AllUtils qw[ uniq ];
 
@@ -9,7 +11,7 @@ with(
     'HTTP::Throwable::Role::BoringText',
 );
 
-enum 'HTTP::Throwable::Type::Method' => [ qw[
+my $method_enum_type = enum "HttpThrowableTypeMethod" => [ qw[
     OPTIONS GET HEAD
     POST PUT DELETE
     TRACE CONNECT
@@ -17,16 +19,16 @@ enum 'HTTP::Throwable::Type::Method' => [ qw[
 
 # TODO: Consider adding a coersion to upper-case lower-cased strings and to
 # uniq the given input.  -- rjbs, 2011-02-21
-subtype 'HTTP::Throwable::Type::MethodList'
-    => as 'ArrayRef'
-    => where { (scalar uniq @{$_}) == (scalar @{$_}) };
+my $method_list_type = subtype "HttpThrowableTypeMethodList",
+    as ArrayRef[ $method_enum_type ],
+    where { (scalar uniq @{$_}) == (scalar @{$_}) };
 
 sub default_status_code { 405 }
 sub default_reason      { 'Method Not Allowed' }
 
 has 'allow' => (
     is       => 'ro',
-    isa      => 'HTTP::Throwable::Type::MethodList[ HTTP::Throwable::Type::Method ]',
+    isa      => $method_list_type,
     required => 1
 );
 
@@ -38,7 +40,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; no Moose::Util::TypeConstraints; 1;
+no Moose::Role; 1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/MethodNotAllowed.pm
+++ b/lib/HTTP/Throwable/Role/Status/MethodNotAllowed.pm
@@ -1,10 +1,10 @@
 package HTTP::Throwable::Role::Status::MethodNotAllowed;
-use Moose::Role;
 
 use Type::Utils qw(subtype as where enum);
 use Types::Standard qw(ArrayRef);
-
 use List::AllUtils qw[ uniq ];
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -40,8 +40,8 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; 1;
 
+1;
 __END__
 
 # ABSTRACT: 405 Method Not Allowed

--- a/lib/HTTP/Throwable/Role/Status/MovedPermanently.pm
+++ b/lib/HTTP/Throwable/Role/Status/MovedPermanently.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::MovedPermanently;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -10,7 +10,7 @@ with(
 sub default_status_code { 301 }
 sub default_reason      { 'Moved Permanently' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/MovedPermanently.pm
+++ b/lib/HTTP/Throwable/Role/Status/MovedPermanently.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::MovedPermanently;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/MultipleChoices.pm
+++ b/lib/HTTP/Throwable/Role/Status/MultipleChoices.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Status::MultipleChoices;
 use Moose::Role;
 
+use Types::Standard qw(Str);
+
 with(
     'HTTP::Throwable',
     'HTTP::Throwable::Role::BoringText',
@@ -9,7 +11,7 @@ with(
 sub default_status_code { 300 }
 sub default_reason      { 'Multiple Choices' }
 
-has 'location' => ( is => 'ro', isa => 'Str' );
+has 'location' => ( is => 'ro', isa => Str );
 
 around 'build_headers' => sub {
     my $next    = shift;

--- a/lib/HTTP/Throwable/Role/Status/MultipleChoices.pm
+++ b/lib/HTTP/Throwable/Role/Status/MultipleChoices.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Status::MultipleChoices;
-use Moose::Role;
 
 use Types::Standard qw(Str);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -23,7 +24,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/NotAcceptable.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotAcceptable.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::NotAcceptable;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 406 }
 sub default_reason      { 'Not Acceptable' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/NotAcceptable.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotAcceptable.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::NotAcceptable;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/NotFound.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotFound.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::NotFound;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/NotFound.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotFound.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::NotFound;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 404 }
 sub default_reason      { 'Not Found' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/NotImplemented.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotImplemented.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::NotImplemented;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/NotImplemented.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotImplemented.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::NotImplemented;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 501 }
 sub default_reason      { 'Not Implemented' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/NotModified.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotModified.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::NotModified;
-use Moose::Role;
+use Moo::Role;
 
 use Plack::Util ();
 
@@ -26,7 +26,7 @@ around 'as_psgi' => sub {
     $psgi;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/NotModified.pm
+++ b/lib/HTTP/Throwable/Role/Status/NotModified.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::NotModified;
+
 use Moo::Role;
 
 use Plack::Util ();

--- a/lib/HTTP/Throwable/Role/Status/PreconditionFailed.pm
+++ b/lib/HTTP/Throwable/Role/Status/PreconditionFailed.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::PreconditionFailed;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/PreconditionFailed.pm
+++ b/lib/HTTP/Throwable/Role/Status/PreconditionFailed.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::PreconditionFailed;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 412 }
 sub default_reason      { 'Precondition Failed' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/ProxyAuthenticationRequired.pm
+++ b/lib/HTTP/Throwable/Role/Status/ProxyAuthenticationRequired.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Status::ProxyAuthenticationRequired;
 use Moose::Role;
 
+use Types::Standard qw(Str ArrayRef);
+
 with(
     'HTTP::Throwable',
     'HTTP::Throwable::Role::BoringText',
@@ -11,7 +13,7 @@ sub default_reason      { 'Proxy Authentication Required' }
 
 has 'proxy_authenticate' => (
     is       => 'ro',
-    isa      => 'Str | ArrayRef[ Str ]',
+    isa      => Str | ArrayRef[ Str ],
     required => 1,
 );
 

--- a/lib/HTTP/Throwable/Role/Status/ProxyAuthenticationRequired.pm
+++ b/lib/HTTP/Throwable/Role/Status/ProxyAuthenticationRequired.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Status::ProxyAuthenticationRequired;
-use Moose::Role;
 
 use Types::Standard qw(Str ArrayRef);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -31,7 +32,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/RequestEntityTooLarge.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestEntityTooLarge.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Status::RequestEntityTooLarge;
-use Moose::Role;
 
 use Types::Standard qw(Str);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -23,7 +24,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/RequestEntityTooLarge.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestEntityTooLarge.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Status::RequestEntityTooLarge;
 use Moose::Role;
 
+use Types::Standard qw(Str);
+
 with(
     'HTTP::Throwable',
     'HTTP::Throwable::Role::BoringText',
@@ -9,7 +11,7 @@ with(
 sub default_status_code { 413 }
 sub default_reason      { 'Request Entity Too Large' }
 
-has 'retry_after' => ( is => 'ro', isa => 'Str' );
+has 'retry_after' => ( is => 'ro', isa => Str );
 
 around 'build_headers' => sub {
     my $next    = shift;

--- a/lib/HTTP/Throwable/Role/Status/RequestTimeout.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestTimeout.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::RequestTimeout;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 408 }
 sub default_reason      { 'Request Timeout' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/RequestTimeout.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestTimeout.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::RequestTimeout;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/RequestURITooLong.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestURITooLong.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::RequestURITooLong;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/RequestURITooLong.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestURITooLong.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::RequestURITooLong;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 414 }
 sub default_reason      { 'Request-URI Too Long' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/RequestedRangeNotSatisfiable.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestedRangeNotSatisfiable.pm
@@ -1,5 +1,6 @@
 package HTTP::Throwable::Role::Status::RequestedRangeNotSatisfiable;
 use Moose::Role;
+use Types::Standard qw(Str);
 
 with(
     'HTTP::Throwable',
@@ -9,7 +10,7 @@ with(
 sub default_status_code { 416 }
 sub default_reason      { 'Requested Range Not Satisfiable' }
 
-has 'content_range' => ( is => 'ro', isa => 'Str' );
+has 'content_range' => ( is => 'ro', isa => Str );
 
 around 'build_headers' => sub {
     my $next    = shift;

--- a/lib/HTTP/Throwable/Role/Status/RequestedRangeNotSatisfiable.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestedRangeNotSatisfiable.pm
@@ -1,6 +1,7 @@
 package HTTP::Throwable::Role::Status::RequestedRangeNotSatisfiable;
-use Moose::Role;
 use Types::Standard qw(Str);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -22,7 +23,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/RequestedRangeNotSatisfiable.pm
+++ b/lib/HTTP/Throwable/Role/Status/RequestedRangeNotSatisfiable.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::RequestedRangeNotSatisfiable;
+
 use Types::Standard qw(Str);
 
 use Moo::Role;

--- a/lib/HTTP/Throwable/Role/Status/SeeOther.pm
+++ b/lib/HTTP/Throwable/Role/Status/SeeOther.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::SeeOther;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/SeeOther.pm
+++ b/lib/HTTP/Throwable/Role/Status/SeeOther.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::SeeOther;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -10,7 +10,7 @@ with(
 sub default_status_code { 303 }
 sub default_reason      { 'See Other' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/ServiceUnavailable.pm
+++ b/lib/HTTP/Throwable/Role/Status/ServiceUnavailable.pm
@@ -1,6 +1,8 @@
 package HTTP::Throwable::Role::Status::ServiceUnavailable;
 use Moose::Role;
 
+use Types::Standard qw(Str);
+
 with(
     'HTTP::Throwable',
     'HTTP::Throwable::Role::BoringText',
@@ -9,7 +11,7 @@ with(
 sub default_status_code { 503 }
 sub default_reason      { 'Service Unavailable' }
 
-has 'retry_after' => ( is => 'ro', isa => 'Str' );
+has 'retry_after' => ( is => 'ro', isa => Str );
 
 around 'build_headers' => sub {
     my $next    = shift;

--- a/lib/HTTP/Throwable/Role/Status/ServiceUnavailable.pm
+++ b/lib/HTTP/Throwable/Role/Status/ServiceUnavailable.pm
@@ -1,7 +1,8 @@
 package HTTP::Throwable::Role::Status::ServiceUnavailable;
-use Moose::Role;
 
 use Types::Standard qw(Str);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -23,7 +24,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/TemporaryRedirect.pm
+++ b/lib/HTTP/Throwable/Role/Status/TemporaryRedirect.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::TemporaryRedirect;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -10,7 +10,7 @@ with(
 sub default_status_code { 307 }
 sub default_reason      { 'Temporary Redirect' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/TemporaryRedirect.pm
+++ b/lib/HTTP/Throwable/Role/Status/TemporaryRedirect.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::TemporaryRedirect;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/Unauthorized.pm
+++ b/lib/HTTP/Throwable/Role/Status/Unauthorized.pm
@@ -1,6 +1,7 @@
 package HTTP::Throwable::Role::Status::Unauthorized;
-use Moose::Role;
 use Types::Standard qw(Str ArrayRef);
+
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -30,7 +31,7 @@ around 'build_headers' => sub {
     $headers;
 };
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/Unauthorized.pm
+++ b/lib/HTTP/Throwable/Role/Status/Unauthorized.pm
@@ -1,5 +1,6 @@
 package HTTP::Throwable::Role::Status::Unauthorized;
 use Moose::Role;
+use Types::Standard qw(Str ArrayRef);
 
 with(
     'HTTP::Throwable',
@@ -11,7 +12,7 @@ sub default_reason      { 'Unauthorized' }
 
 has 'www_authenticate' => (
     is       => 'ro',
-    isa      => 'Str | ArrayRef[ Str ]',
+    isa      => Str | ArrayRef[Str],
     required => 1,
 );
 

--- a/lib/HTTP/Throwable/Role/Status/Unauthorized.pm
+++ b/lib/HTTP/Throwable/Role/Status/Unauthorized.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::Unauthorized;
+
 use Types::Standard qw(Str ArrayRef);
 
 use Moo::Role;

--- a/lib/HTTP/Throwable/Role/Status/UnsupportedMediaType.pm
+++ b/lib/HTTP/Throwable/Role/Status/UnsupportedMediaType.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::UnsupportedMediaType;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/Status/UnsupportedMediaType.pm
+++ b/lib/HTTP/Throwable/Role/Status/UnsupportedMediaType.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::UnsupportedMediaType;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -9,7 +9,7 @@ with(
 sub default_status_code { 415 }
 sub default_reason      { 'Unsupported Media Type' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/UseProxy.pm
+++ b/lib/HTTP/Throwable/Role/Status/UseProxy.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::Status::UseProxy;
-use Moose::Role;
+use Moo::Role;
 
 with(
     'HTTP::Throwable',
@@ -10,7 +10,7 @@ with(
 sub default_status_code { 305 }
 sub default_reason      { 'Use Proxy' }
 
-no Moose::Role; 1;
+1;
 
 __END__
 

--- a/lib/HTTP/Throwable/Role/Status/UseProxy.pm
+++ b/lib/HTTP/Throwable/Role/Status/UseProxy.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::Status::UseProxy;
+
 use Moo::Role;
 
 with(

--- a/lib/HTTP/Throwable/Role/TextBody.pm
+++ b/lib/HTTP/Throwable/Role/TextBody.pm
@@ -1,4 +1,5 @@
 package HTTP::Throwable::Role::TextBody;
+
 use Moo::Role;
 
 sub body { $_[0]->text_body }

--- a/lib/HTTP/Throwable/Role/TextBody.pm
+++ b/lib/HTTP/Throwable/Role/TextBody.pm
@@ -1,5 +1,5 @@
 package HTTP::Throwable::Role::TextBody;
-use Moose::Role;
+use Moo::Role;
 
 sub body { $_[0]->text_body }
 
@@ -16,7 +16,6 @@ sub as_string { $_[0]->body }
 
 requires 'text_body';
 
-no Moose::Role;
 1;
 
 __END__

--- a/lib/HTTP/Throwable/Variant.pm
+++ b/lib/HTTP/Throwable/Variant.pm
@@ -9,7 +9,8 @@ use Package::Variant
 
 sub make_variant {
     my ($class, $target_package, %arguments) = @_;
-    extends @{ $arguments{superclasses} };
+    extends @{ $arguments{superclasses} }
+        if  @{ $arguments{superclasses} };
     with @{ $arguments{roles} };
 }
 

--- a/lib/HTTP/Throwable/Variant.pm
+++ b/lib/HTTP/Throwable/Variant.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Package::Variant
-  importing => ['Moose', 'MooseX::StrictConstructor'],
+  importing => ['Moo', 'MooX::StrictConstructor'],
   subs      => [ qw(extends with) ];
 
 sub make_variant {

--- a/lib/HTTP/Throwable/Variant.pm
+++ b/lib/HTTP/Throwable/Variant.pm
@@ -1,0 +1,27 @@
+package HTTP::Throwable::Variant;
+
+use strict;
+use warnings;
+
+use Package::Variant
+  importing => ['Moose', 'MooseX::StrictConstructor'],
+  subs      => [ qw(extends with) ];
+
+sub make_variant {
+    my ($class, $target_package, %arguments) = @_;
+    extends @{ $arguments{superclasses} };
+    with @{ $arguments{roles} };
+}
+
+1;
+__END__
+
+# ABSTRACT: a package that constructs Moo-based HTTP::Throwables for you
+
+=head1 OVERVIEW
+
+This package is used by L<HTTP::Throwable::Factory> to build
+exceptions at runtime.  The exceptions are L<Moo>-based, with
+L<MooX::StrictConstructor> applied as well.  It takes two arguments:
+C<superclasses>, an arrayref of classes to extend, and C<roles>, an
+arrayref of roles to compose.

--- a/t/001-basic.t
+++ b/t/001-basic.t
@@ -4,7 +4,6 @@ use warnings;
 
 use Test::More;
 use Test::Fatal;
-use Test::Moose;
 use t::lib::Test::HT;
 
 ht_test(

--- a/t/001-basic.t
+++ b/t/001-basic.t
@@ -48,7 +48,7 @@ subtest "strict constructors all around" => sub {
 
   like(
     $error,
-    qr{unknown attribute\(s\) init_arg passed to the constructor},
+    qr{Found unknown attribute\(s\) passed to the constructor},
     "http throwables have strict constructors",
   );
 };

--- a/t/400-all.t
+++ b/t/400-all.t
@@ -61,7 +61,7 @@ like(
             allow => [ 'GET', 'PUT', 'OPTIONS', 'PUT' ],
         });
     },
-    qr/Attribute \(allow\) does not pass the type constraint/,
+    qr/did not pass type constraint.+\{"allow"\}/,
     '... type check works (must be unique list)',
 );
 
@@ -71,7 +71,7 @@ like(
             allow => [ 'GET', 'PUT', 'OPTIONS', 'TEST' ],
         });
     },
-    qr/Attribute \(allow\) does not pass the type constraint/,
+    qr/did not pass type constraint.+\{"allow"\}/,
     '... type check works (must be all known methods)',
 );
 

--- a/t/400-all.t
+++ b/t/400-all.t
@@ -5,7 +5,6 @@ use warnings;
 
 use Test::More;
 use Test::Fatal;
-use Test::Moose;
 
 use t::lib::Test::HT;
 

--- a/t/500-all.t
+++ b/t/500-all.t
@@ -5,7 +5,6 @@ use warnings;
 use Test::Deep qw(ignore re);
 use Test::More;
 use Test::Fatal;
-use Test::Moose;
 
 use t::lib::Test::HT;
 

--- a/t/lib/Test/HT.pm
+++ b/t/lib/Test/HT.pm
@@ -6,7 +6,6 @@ use HTTP::Throwable::Factory;
 use Scalar::Util qw(reftype);
 use Test::Deep qw(cmp_deeply bag);
 use Test::Fatal;
-use Test::Moose;
 use Test::More;
 
 use Sub::Exporter -setup => {
@@ -52,8 +51,8 @@ sub ht_test {
                     $factory_class->throw($identifier, $arg);
                 };
 
-                does_ok($err, 'HTTP::Throwable');
-                does_ok($err, 'Throwable');
+                ok( $err->does('HTTP::Throwable') );
+                ok( $err->does('Throwable') );
 
                 if (my $code = $extra->{code}) {
                     is($err->status_code, $code, "got expected status code");


### PR DESCRIPTION
Hello Ricardo,

This patchset switches HTTP::Throwable from Moose to Moo-based.  It passes all of the current tests, and I've also tested it with the Moose-based subclassing in timbunce/WebAPI-DBIC.  I've added dependecies on Type::Tiny, Types::Standard, Package::Variant, and namespace::clean.  Please let me know if there's anything you would like me to change or fix.  Thank you and have a great day!

Cheers,
Fitz