### PR TITLE
create a lookup registry for status code to ident

### DIFF
--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -84,6 +84,47 @@ sub class_for {
     return $class;
 }
 
+sub ident_for_status_code {
+    my ($self, $code) = @_;
+
+    my %lookup = (
+        300 => 'MultipleChoices',
+        301 => 'MovedPermanently',
+        302 => 'Found',
+        303 => 'SeeOther',
+        304 => 'NotModified',
+        305 => 'UseProxy',
+        307 => 'TemporaryRedirect',
+
+        400 => 'BadRequest',
+        401 => 'Unauthorized',
+        403 => 'Forbidden',
+        404 => 'NotFound',
+        405 => 'MethodNotAllowed',
+        406 => 'NotAcceptable',
+        407 => 'ProxyAuthenticationRequired',
+        408 => 'RequestTimeout',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'LengthRequired',
+        412 => 'PreconditionFailed',
+        413 => 'RequestEntityTooLarge',
+        414 => 'RequestURITooLong',
+        415 => 'UnsupportedMediaType',
+        416 => 'RequestedRangeNotSatisfiable',
+        417 => 'ExpectationFailed',
+
+        500 => 'InternalServerError',
+        501 => 'NotImplemented',
+        502 => 'BadGateway',
+        503 => 'Status::ServiceUnavailable',
+        504 => 'GatewayTimeout',
+        505 => 'HTTPVersionNotSupported',
+    );
+
+    return $lookup{$code};
+}
+
 1;
 
 __END__


### PR DESCRIPTION
It would be nice if we had an easy way to convert status codes into
idents. This provides a method in `HTTP::Throwable::Factory` for doing
such a lookup.