### PR TITLE
avoid relying on . being in @INC

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,4 +27,4 @@ Test::Fatal           = 0.003
 HTTP::Request::Common = 0
 
 [RemovePrereqs]
-remove = t::lib::Test::HT
+remove = Test::HT

--- a/t/001-basic.t
+++ b/t/001-basic.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More;
 use Test::Fatal;
-use t::lib::Test::HT;
+use lib 't/lib';
+use Test::HT;
 
 ht_test(
     { status_code => 500, reason => 'Internal Server Error' },

--- a/t/300-all.t
+++ b/t/300-all.t
@@ -3,7 +3,8 @@ use strict;
 use warnings;
 
 use Test::More;
-use t::lib::Test::HT;
+use lib 't/lib';
+use Test::HT;
 
 ht_test(MultipleChoices => { location => '/test' }, {
     code    => 300,

--- a/t/400-all.t
+++ b/t/400-all.t
@@ -6,7 +6,8 @@ use warnings;
 use Test::More;
 use Test::Fatal;
 
-use t::lib::Test::HT;
+use lib 't/lib';
+use Test::HT;
 
 ht_test(BadRequest => {}, {
     code   => 400,

--- a/t/500-all.t
+++ b/t/500-all.t
@@ -6,7 +6,8 @@ use Test::Deep qw(ignore re);
 use Test::More;
 use Test::Fatal;
 
-use t::lib::Test::HT;
+use lib 't/lib';
+use Test::HT;
 
 ht_test(InternalServerError => {}, {
     code   => 500,

--- a/t/lib/Test/HT.pm
+++ b/t/lib/Test/HT.pm
@@ -1,4 +1,4 @@
-package t::lib::Test::HT;
+package Test::HT;
 use strict;
 use warnings;
 


### PR DESCRIPTION
. may no longer be available by default in @INC - see https://rt.perl.org/Ticket/Display.html?id=127810
