### PR TITLE
Correct ServiceUnavailable ident in code lookup

### DIFF
--- a/lib/HTTP/Throwable/Factory.pm
+++ b/lib/HTTP/Throwable/Factory.pm
@@ -125,7 +125,7 @@ my %lookup = (
     500 => 'InternalServerError',
     501 => 'NotImplemented',
     502 => 'BadGateway',
-    503 => 'Status::ServiceUnavailable',
+    503 => 'ServiceUnavailable',
     504 => 'GatewayTimeout',
     505 => 'HTTPVersionNotSupported',
 );


### PR DESCRIPTION
The ServiceUnavailable Role doesn't have an extra Service:: layer
to the package name.  This should resolve throwing a 503 exception.